### PR TITLE
Before after date filters

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -9,6 +9,7 @@
 enabled_site_setting :url_filters_enabled
 
 PLUGIN_NAME = "discourse_url_filters".freeze
+BASIC_DATE_REGEX = /\d{4}-\d{2}-\d{2}/
 
 after_initialize do
 
@@ -20,6 +21,28 @@ after_initialize do
       if after = topic_query.options[:after]
         if (after = after.to_i) > 0
           results = results.where('topics.created_at > ?', after.days.ago)
+        end
+      end
+      results
+    end
+
+    # After Date (yyyy-mm-dd)
+    TopicQuery.add_custom_filter(:after_date) do |results, topic_query|
+      if after_date = topic_query.options[:after_date]
+        if BASIC_DATE_REGEX.match(after_date)
+          parsed_after_date = Date.parse(after_date) rescue nil
+          results = results.where('topics.created_at > ?', parsed_after_date) if parsed_after_date
+        end
+      end
+      results
+    end
+
+    # Before Date (yyyy-mm-dd)
+    TopicQuery.add_custom_filter(:before_date) do |results, topic_query|
+      if before_date = topic_query.options[:before_date]
+        if BASIC_DATE_REGEX.match(before_date)
+          parsed_before_date = Date.parse(before_date) rescue nil
+          results = results.where('topics.created_at < ?', parsed_before_date) if parsed_before_date
         end
       end
       results

--- a/plugin.rb
+++ b/plugin.rb
@@ -30,8 +30,11 @@ after_initialize do
     TopicQuery.add_custom_filter(:after_date) do |results, topic_query|
       if after_date = topic_query.options[:after_date]
         if BASIC_DATE_REGEX.match(after_date)
-          parsed_after_date = Date.parse(after_date) rescue nil
-          results = results.where('topics.created_at > ?', parsed_after_date) if parsed_after_date
+          begin
+            parsed_after_date = Date.parse(after_date)
+            results = results.where('topics.created_at > ?', parsed_after_date)
+          rescue Date::Error
+          end
         end
       end
       results
@@ -41,8 +44,11 @@ after_initialize do
     TopicQuery.add_custom_filter(:before_date) do |results, topic_query|
       if before_date = topic_query.options[:before_date]
         if BASIC_DATE_REGEX.match(before_date)
-          parsed_before_date = Date.parse(before_date) rescue nil
-          results = results.where('topics.created_at < ?', parsed_before_date) if parsed_before_date
+          begin
+            parsed_before_date = Date.parse(before_date)
+            results = results.where('topics.created_at < ?', parsed_before_date)
+          rescue Date::Error
+          end
         end
       end
       results

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -43,4 +43,3 @@ describe 'plugin' do
     end
   end
 end
-

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'plugin' do
+  before { SiteSetting.url_filters_enabled = true }
+
+  describe 'Topic Queries' do
+    describe 'after_or_before_date' do
+      before do
+        @topic = Fabricate(:topic, created_at: 10.days.ago)
+        @topic2 = Fabricate(:topic, created_at: 8.days.ago)
+        @topic3 = Fabricate(:topic, created_at: 6.days.ago)
+        @user = Fabricate(:user)
+      end
+
+      it 'only shows topics after specified date' do
+        after_date = 9.days.ago.strftime("%Y-%m-%d")
+        query = TopicQuery.new(@user, { after_date: after_date }).list_latest
+        expect(query.topics.length).to eq(2)
+        expect(query.topics).to contain_exactly(@topic2, @topic3)
+      end
+
+      it 'only shows topics before specified date' do
+        before_date = 9.days.ago.strftime("%Y-%m-%d")
+        query = TopicQuery.new(@user, { before_date: before_date }).list_latest
+        expect(query.topics.length).to eq(1)
+        expect(query.topics).to contain_exactly(@topic)
+      end
+
+      it 'only shows topics between before and after dates' do
+        before_date = 7.days.ago.strftime("%Y-%m-%d")
+        after_date = 9.days.ago.strftime("%Y-%m-%d")
+        query = TopicQuery.new(@user, { before_date: before_date, after_date: after_date }).list_latest
+        expect(query.topics.length).to eq(1)
+        expect(query.topics).to contain_exactly(@topic2)
+      end
+
+    end
+  end
+end
+

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -7,38 +7,36 @@ describe 'plugin' do
 
   describe 'Topic Queries' do
     describe 'after_or_before_date' do
-      before do
-        @topic = Fabricate(:topic, created_at: 10.days.ago)
-        @topic2 = Fabricate(:topic, created_at: 8.days.ago)
-        @topic3 = Fabricate(:topic, created_at: 6.days.ago)
-        @user = Fabricate(:user)
-      end
+      fab!(:topic1) { Fabricate(:topic, created_at: 10.days.ago) }
+      fab!(:topic2) { Fabricate(:topic, created_at: 8.days.ago) }
+      fab!(:topic3) { Fabricate(:topic, created_at: 6.days.ago) }
+      fab!(:user) { Fabricate(:user) }
 
       it 'only shows topics after specified date' do
         after_date = 9.days.ago.strftime("%Y-%m-%d")
-        query = TopicQuery.new(@user, { after_date: after_date }).list_latest
+        query = TopicQuery.new(user, { after_date: after_date }).list_latest
         expect(query.topics.length).to eq(2)
-        expect(query.topics).to contain_exactly(@topic2, @topic3)
+        expect(query.topics).to contain_exactly(topic2, topic3)
       end
 
       it 'only shows topics before specified date' do
         before_date = 9.days.ago.strftime("%Y-%m-%d")
-        query = TopicQuery.new(@user, { before_date: before_date }).list_latest
+        query = TopicQuery.new(user, { before_date: before_date }).list_latest
         expect(query.topics.length).to eq(1)
-        expect(query.topics).to contain_exactly(@topic)
+        expect(query.topics).to contain_exactly(topic1)
       end
 
       it 'only shows topics between before and after dates' do
         before_date = 7.days.ago.strftime("%Y-%m-%d")
         after_date = 9.days.ago.strftime("%Y-%m-%d")
-        query = TopicQuery.new(@user, { before_date: before_date, after_date: after_date }).list_latest
+        query = TopicQuery.new(user, { before_date: before_date, after_date: after_date }).list_latest
         expect(query.topics.length).to eq(1)
-        expect(query.topics).to contain_exactly(@topic2)
+        expect(query.topics).to contain_exactly(topic2)
       end
 
       it 'does not filter for malformed date' do
         before_date = 'asdf'
-        query = TopicQuery.new(@user, { before_date: before_date }).list_latest
+        query = TopicQuery.new(user, { before_date: before_date }).list_latest
         expect(query.topics.length).to eq(3)
       end
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -36,6 +36,12 @@ describe 'plugin' do
         expect(query.topics).to contain_exactly(@topic2)
       end
 
+      it 'does not filter for malformed date' do
+        before_date = 'asdf'
+        query = TopicQuery.new(@user, { before_date: before_date }).list_latest
+        expect(query.topics.length).to eq(3)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Add `before_date` and `after_date` filters to filter topics by date in 'yyyy-mm-dd' format.