### PR TITLE
SECURITY: Group member filters bypass group membership visibility

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,10 @@ enabled_site_setting :url_filters_enabled
 after_initialize do
   module ::DiscourseUrlFilters
     BASIC_DATE_REGEX = /\d{4}-\d{2}-\d{2}/
+
+    def self.group_with_visible_members(name, user)
+      Group.visible_groups(user).members_visible_groups(user).find_by(name: name)
+    end
   end
 
   # After
@@ -120,16 +124,20 @@ after_initialize do
   # Filter by topics where the user is a member of the specified group
   TopicQuery.add_custom_filter(:topic_author) do |results, topic_query|
     if topic_author_param = topic_query.options[:topic_author]
-      group = Group.find_by(name: topic_author_param)
-      results = results.where(<<~SQL, group_id: group.id) if group
-        topics.id IN (
-          SELECT posts.topic_id
-          FROM posts
-          INNER JOIN group_users gu ON gu.user_id = posts.user_id
-          WHERE gu.group_id = :group_id
-          AND posts.post_number = 1
-        )
-        SQL
+      group = DiscourseUrlFilters.group_with_visible_members(topic_author_param, topic_query.user)
+      if group
+        results = results.where(<<~SQL, group_id: group.id)
+          topics.id IN (
+            SELECT posts.topic_id
+            FROM posts
+            INNER JOIN group_users gu ON gu.user_id = posts.user_id
+            WHERE gu.group_id = :group_id
+            AND posts.post_number = 1
+          )
+          SQL
+      else
+        results = results.none
+      end
     end
     results
   end
@@ -137,17 +145,21 @@ after_initialize do
   # Has Reply From
   TopicQuery.add_custom_filter(:reply_from) do |results, topic_query|
     if reply_from_param = topic_query.options[:reply_from]
-      group = Group.find_by(name: reply_from_param)
-      results = results.where(<<~SQL, group_id: group.id, post_type: Post.types[:regular]) if group
-        topics.id IN (
-          SELECT posts.topic_id
-          FROM posts
-          INNER JOIN group_users gu ON gu.user_id = posts.user_id
-          WHERE gu.group_id = :group_id
-          AND posts.post_number > 1
-          AND posts.post_type = :post_type
-        )
-        SQL
+      group = DiscourseUrlFilters.group_with_visible_members(reply_from_param, topic_query.user)
+      if group
+        results = results.where(<<~SQL, group_id: group.id, post_type: Post.types[:regular])
+          topics.id IN (
+            SELECT posts.topic_id
+            FROM posts
+            INNER JOIN group_users gu ON gu.user_id = posts.user_id
+            WHERE gu.group_id = :group_id
+            AND posts.post_number > 1
+            AND posts.post_type = :post_type
+          )
+          SQL
+      else
+        results = results.none
+      end
     end
     results
   end
@@ -155,7 +167,7 @@ after_initialize do
   # No Reply From
   TopicQuery.add_custom_filter(:no_reply_from) do |results, topic_query|
     if no_reply_from_param = topic_query.options[:no_reply_from]
-      group = Group.find_by(name: no_reply_from_param)
+      group = DiscourseUrlFilters.group_with_visible_members(no_reply_from_param, topic_query.user)
       results = results.where(<<~SQL, group_id: group.id, post_type: Post.types[:regular]) if group
         topics.id NOT IN (
           SELECT posts.topic_id

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -39,5 +39,62 @@ describe Plugin::Instance do
         expect(query.topics.length).to eq(3)
       end
     end
+
+    describe "group member filters" do
+      fab!(:viewer, :user)
+      fab!(:group_member, :user)
+      fab!(:other_user, :user)
+
+      fab!(:hidden_members_group) do
+        Fabricate(
+          :group,
+          name: "hidden_members",
+          visibility_level: Group.visibility_levels[:public],
+          members_visibility_level: Group.visibility_levels[:owners],
+        )
+      end
+
+      fab!(:member_topic) do
+        Fabricate(:topic, user: group_member, title: "Topic by hidden group member")
+      end
+
+      fab!(:member_topic_op) do
+        Fabricate(:post, topic: member_topic, user: group_member, post_number: 1)
+      end
+
+      fab!(:reply_topic) do
+        Fabricate(:topic, user: other_user, title: "Topic with hidden group reply")
+      end
+
+      fab!(:reply_topic_op) do
+        Fabricate(:post, topic: reply_topic, user: other_user, post_number: 1)
+      end
+
+      fab!(:member_reply) do
+        Fabricate(:post, topic: reply_topic, user: group_member, post_number: 2)
+      end
+
+      fab!(:unrelated_topic) { Fabricate(:topic, user: other_user, title: "Unrelated topic") }
+
+      fab!(:unrelated_topic_op) do
+        Fabricate(:post, topic: unrelated_topic, user: other_user, post_number: 1)
+      end
+
+      before { hidden_members_group.add(group_member) }
+
+      def filtered_topic_ids(options)
+        TopicQuery.new(viewer, options).list_latest.topics.map(&:id)
+      end
+
+      it "respects hidden group member visibility", :aggregate_failures do
+        expect(filtered_topic_ids(topic_author: hidden_members_group.name)).to be_empty
+        expect(filtered_topic_ids(reply_from: hidden_members_group.name)).to be_empty
+        expect(filtered_topic_ids(no_reply_from: hidden_members_group.name)).to contain_exactly(
+          member_topic.id,
+          reply_topic.id,
+          unrelated_topic.id,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Topic list could be filtered by group that has members hidden. Users could see topic authors and know they are part of the group.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1267


Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>