### PR TITLE
FIX: Respect tag visibility in include_tags/exclude_tags filters

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -88,16 +88,10 @@ after_initialize do
   TopicQuery.add_custom_filter(:include_tags) do |results, topic_query|
     if tags_param = topic_query.options[:include_tags]
       tags = tags_param.split(",")
-      tag_ids = Tag.where(name: tags).pluck(:id)
+      tag_ids = Tag.visible(topic_query.guardian).where(name: tags).pluck(:id)
+      topic_ids = TopicTag.where(tag_id: tag_ids).select(:topic_id)
 
-      results = results.where(<<~SQL, tag_ids: tag_ids)
-      topics.id IN (
-        SELECT topic_tags.topic_id
-        FROM topic_tags
-        INNER JOIN tags ON tags.id = topic_tags.tag_id
-        WHERE tags.id IN (:tag_ids)
-      )
-      SQL
+      results = tag_ids.empty? ? results.none : results.where(id: topic_ids)
     end
     results
   end
@@ -106,16 +100,12 @@ after_initialize do
   TopicQuery.add_custom_filter(:exclude_tags) do |results, topic_query|
     if tags_param = topic_query.options[:exclude_tags]
       tags = tags_param.split(",")
-      tag_ids = Tag.where(name: tags).pluck(:id)
+      tag_ids = Tag.visible(topic_query.guardian).where(name: tags).pluck(:id)
 
-      results = results.where(<<~SQL, tag_ids: tag_ids)
-      topics.id NOT IN (
-        SELECT topic_tags.topic_id
-        FROM topic_tags
-        INNER JOIN tags ON tags.id = topic_tags.tag_id
-        WHERE tags.id IN (:tag_ids)
-      )
-      SQL
+      if tag_ids.present?
+        topic_ids = TopicTag.where(tag_id: tag_ids).select(:topic_id)
+        results = results.where.not(id: topic_ids)
+      end
     end
     results
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 describe Plugin::Instance do
-  before do
-    SiteSetting.url_filters_enabled = true
-    SiteSetting.tagging_enabled = true
-  end
+  before { SiteSetting.url_filters_enabled = true }
 
   describe "Topic Queries" do
     describe "after_or_before_date" do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -45,20 +45,79 @@ describe Plugin::Instance do
 
     describe "hidden tag filters" do
       fab!(:user)
+      fab!(:admin)
+      fab!(:members_group) { Fabricate(:group, name: "url-filter-members") }
       fab!(:hidden_tag) { Fabricate(:tag, name: "private-tag") }
+      fab!(:public_tag) { Fabricate(:tag, name: "public-tag") }
       fab!(:topic_with_hidden_tag) { Fabricate(:topic, tags: [hidden_tag]) }
+      fab!(:topic_with_public_tag) { Fabricate(:topic, tags: [public_tag]) }
       fab!(:topic_without_hidden_tag, :topic)
 
-      before { Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name]) }
+      before do
+        Fabricate(
+          :tag_group,
+          permissions: {
+            "staff" => 1,
+            members_group.name => 1,
+          },
+          tag_names: [hidden_tag.name],
+        )
+      end
+
+      def topic_ids(actor, options)
+        TopicQuery.new(actor, options).list_latest.topics.map(&:id)
+      end
 
       it "does not reveal hidden tag associations", :aggregate_failures do
         include_query = TopicQuery.new(user, include_tags: hidden_tag.name).list_latest
         expect(include_query.topics).to be_empty
 
+        # Excluding a tag the user cannot see is a no-op, so the topic carrying
+        # the hidden tag must still be present in the list.
         exclude_query = TopicQuery.new(user, exclude_tags: hidden_tag.name).list_latest
-        expect(exclude_query.topics).to contain_exactly(
-          topic_with_hidden_tag,
-          topic_without_hidden_tag,
+        expect(exclude_query.topics).to include(topic_with_hidden_tag, topic_without_hidden_tag)
+      end
+
+      it "still filters by a visible tag for a regular user", :aggregate_failures do
+        expect(topic_ids(user, include_tags: public_tag.name)).to contain_exactly(
+          topic_with_public_tag.id,
+        )
+
+        excluded = topic_ids(user, exclude_tags: public_tag.name)
+        expect(excluded).to include(topic_with_hidden_tag.id, topic_without_hidden_tag.id)
+        expect(excluded).not_to include(topic_with_public_tag.id)
+      end
+
+      it "treats a hidden tag the same as a nonexistent one (no oracle)", :aggregate_failures do
+        expect(topic_ids(user, include_tags: "does-not-exist")).to be_empty
+        expect(topic_ids(user, exclude_tags: "does-not-exist")).to include(topic_with_hidden_tag.id)
+      end
+
+      it "does not let a hidden tag in a multi-tag include leak associations" do
+        # public-tag is visible, private-tag is not: results must match only the
+        # visible tag, never the hidden one.
+        expect(
+          topic_ids(user, include_tags: "#{public_tag.name},#{hidden_tag.name}"),
+        ).to contain_exactly(topic_with_public_tag.id)
+      end
+
+      it "lets a member of a permitted group filter by the restricted tag", :aggregate_failures do
+        members_group.add(user)
+
+        expect(topic_ids(user, include_tags: hidden_tag.name)).to contain_exactly(
+          topic_with_hidden_tag.id,
+        )
+        expect(topic_ids(user, exclude_tags: hidden_tag.name)).not_to include(
+          topic_with_hidden_tag.id,
+        )
+      end
+
+      it "lets an admin filter by the restricted tag", :aggregate_failures do
+        expect(topic_ids(admin, include_tags: hidden_tag.name)).to contain_exactly(
+          topic_with_hidden_tag.id,
+        )
+        expect(topic_ids(admin, exclude_tags: hidden_tag.name)).not_to include(
+          topic_with_hidden_tag.id,
         )
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe Plugin::Instance do
-  before { SiteSetting.url_filters_enabled = true }
+  before do
+    SiteSetting.url_filters_enabled = true
+    SiteSetting.tagging_enabled = true
+  end
 
   describe "Topic Queries" do
     describe "after_or_before_date" do
@@ -37,6 +40,26 @@ describe Plugin::Instance do
         before_date = "asdf"
         query = TopicQuery.new(user, { before_date: before_date }).list_latest
         expect(query.topics.length).to eq(3)
+      end
+    end
+
+    describe "hidden tag filters" do
+      fab!(:user)
+      fab!(:hidden_tag) { Fabricate(:tag, name: "private-tag") }
+      fab!(:topic_with_hidden_tag) { Fabricate(:topic, tags: [hidden_tag]) }
+      fab!(:topic_without_hidden_tag, :topic)
+
+      before { Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name]) }
+
+      it "does not reveal hidden tag associations", :aggregate_failures do
+        include_query = TopicQuery.new(user, include_tags: hidden_tag.name).list_latest
+        expect(include_query.topics).to be_empty
+
+        exclude_query = TopicQuery.new(user, exclude_tags: hidden_tag.name).list_latest
+        expect(exclude_query.topics).to contain_exactly(
+          topic_with_hidden_tag,
+          topic_without_hidden_tag,
+        )
       end
     end
 


### PR DESCRIPTION
include_tags/exclude_tags resolved tags with `Tag.where(name:)`, ignoring visibility.
A user could pass a restricted tag name and infer which visible topics carry it.
Fixed by resolving IDs through `Tag.visible(guardian)`, matching core tag filtering.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>